### PR TITLE
docs: add OctoAcme project management README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,44 @@
+# OctoAcme Project Management Docs
+
+This folder contains the living project management process documentation used at OctoAcme. The goal is to give new and existing teammates a single place to find how we initiate, plan, execute, release, and improve work across cross-functional projects.
+
+## Process Overview
+
+OctoAcme follows a structured, customer-first, iterative approach that emphasizes clear roles, measurable outcomes, and continuous improvement.
+
+- Initiation: Validate ideas, align stakeholders, and define success with a short Project One-pager.
+- Planning: Break work into shippable increments, prioritize and estimate the backlog, surface dependencies and risks.
+- Execution & Tracking: Use a project board and disciplined PR/CI practices; hold regular team rhythms to surface blockers and show progress.
+- Release & Deployment: Meet pre-release criteria, run smoke tests, have rollback plans and post-deploy verifications.
+- Risk, Communication & Escalation: Maintain a risk register, run weekly status updates, and escalate issues along defined paths.
+- Roles & Personas: Clear ownership by PM, PdM, Devs, QA, and stakeholders with defined responsibilities.
+- Retrospective & Continuous Improvement: Capture learnings after sprints, releases, and incidents; turn them into tracked action items.
+
+## Docs Index
+
+- [Overview](./octoacme-project-management-overview.md)
+- [Project Initiation](./octoacme-project-initiation.md)
+- [Project Planning](./octoacme-project-planning.md)
+- [Execution & Tracking](./octoacme-execution-and-tracking.md)
+- [Risk & Communication](./octoacme-risks-and-communication.md)
+- [Release & Deployment](./octoacme-release-and-deployment.md)
+- [Retrospective & Continuous Improvement](./octoacme-retrospective-and-continuous-improvement.md)
+- [Roles & Personas](./octoacme-roles-and-personas.md)
+
+## How to use these docs
+
+- Start with the Overview for an at-a-glance understanding of our lifecycle and roles.
+- Use the Project One-pager during Initiation to capture problem, goal, and success metrics.
+- Keep the project README updated as the single source of truth for status, links, and key artifacts.
+- Add process-specific details to this repo's docs/ folder (or to .copilot/ if you want Copilot Spaces to use them as context).
+- When adding or changing process docs, use the `.github/ISSUE_TEMPLATE/add-update-content-to-process-docs.yml` template to request edits and track acceptance criteria.
+
+## Acceptance Checklist (for new/updated process docs)
+
+- [ ] Content aligns with existing process docs
+- [ ] Update improves clarity or closes a documented gap
+- [ ] Proposed content has been reviewed with stakeholders (if needed)
+
+## Questions or feedback
+
+If you have updates, corrections, or additional process guidance to add, open an issue using the "Add Content to Project Management Process Docs" template and link it to the relevant doc.


### PR DESCRIPTION
Adds docs/README.md: a centralized README summarizing OctoAcme project management processes and linking to the existing process docs in docs/.

Related to: #2 

Acceptance criteria:

Content aligns with existing process docs
README improves clarity and discoverability
Proposed content pending stakeholder review (if needed)